### PR TITLE
Simplify how to run api-compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ git submodule update --recursive --init
 ```
 Build source code
 ```
-$ ./gradlew buildGoogleApiConfigGen
+$ ./gradlew buildApplication
 ```
 For running tests, you need to have `protoc` in your path. If you don't
 already have protoc version 3, you can download
@@ -99,17 +99,17 @@ apis:
 
 ### Executing the Google API Compiler
 
-Once the jar 'gapi-config-gen-with-deps-0.0.5-SNAPSHOT.jar' is built under the
+Once the jar 'api-compiler-with-deps-0.0.5-SNAPSHOT.jar' is built under the
 build/libs directory, you can run the jar using the following command:
 
 ```
-$ alias gapi-config-gen='java -jar <path to gapi-config-gen-with-deps-0.0.5-SNAPSHOT.jar>'
+$ alias api-compiler='java -jar <path to api-compiler-with-deps-0.0.5-SNAPSHOT.jar>'
 DESCRIPTOR_FILE=<PATH TO out.descriptor>
 CONFIG_FILE=<path to yaml file>
 JSON_FILE_NAME=<json output file name>
 BINARY_FILE_NAME=<binary output file name>
 
-gapi-config-gen \
+api-compiler \
 --configs $CONFIG_FILE \
 --descriptor $DESCRIPTOR_FILE \
 --json_out $JSON_FILE_NAME \
@@ -127,12 +127,12 @@ Either format can be used to configure a Google Cloud Endpoints API.
 Validate an OpenAPI Specification and create the corresponding service configuration.
 
 ```
-alias gapi-config-gen='java -jar <path to gapi-service-config-gen-with-deps-0.0.5-SNAPSHOT.jar>'
+alias api-compiler='java -jar <path to api-compiler-with-deps-0.0.5-SNAPSHOT.jar>'
 OPENAPI_FILE=<OpenAPI Spec filename>
 JSON_FILE_NAME=<json output file name>
 BINARY_FILE_NAME=<binary output file name>
 
-gapi-config-gen \
+api-compiler \
 --openapi $OPENAPI_FILE \
 --json_out $JSON_FILE_NAME \
 --bin_out $BINARY_FILE_NAME

--- a/README.md
+++ b/README.md
@@ -36,29 +36,6 @@ Cloud Bigtable, IAM, and more.
 Google API compiler is used by other tools like [googleapis/toolkit](https://github.com/googleapis/toolkit)
 to read the users API definition and autogenerate client libraries.
 
-## Compile Google API Compiler
-
-Clone the _Google API Compiler_ repo
-```
-$ git clone https://github.com/googleapis/api-compiler
-```
-Update submodules
-```
-$ git submodule update --recursive --init
-```
-Build source code
-```
-$ ./gradlew buildApplication
-```
-For running tests, you need to have `protoc` in your path. If you don't
-already have protoc version 3, you can download
-it from https://github.com/google/protobuf/releases and set a symbolic link to
-the protoc.
-```
-# Example
-$ sudo ln -s  <Path to the downloaded protoc> /usr/local/bin/protoc
-```
-
 ## Creating service configuration from proto files
 
 ### Creating a proto descriptor file
@@ -99,17 +76,13 @@ apis:
 
 ### Executing the Google API Compiler
 
-Once the jar 'api-compiler-with-deps-0.0.5-SNAPSHOT.jar' is built under the
-build/libs directory, you can run the jar using the following command:
-
 ```
-$ alias api-compiler='java -jar <path to api-compiler-with-deps-0.0.5-SNAPSHOT.jar>'
 DESCRIPTOR_FILE=<PATH TO out.descriptor>
 CONFIG_FILE=<path to yaml file>
 JSON_FILE_NAME=<json output file name>
 BINARY_FILE_NAME=<binary output file name>
 
-api-compiler \
+./run.sh \
 --configs $CONFIG_FILE \
 --descriptor $DESCRIPTOR_FILE \
 --json_out $JSON_FILE_NAME \
@@ -127,12 +100,11 @@ Either format can be used to configure a Google Cloud Endpoints API.
 Validate an OpenAPI Specification and create the corresponding service configuration.
 
 ```
-alias api-compiler='java -jar <path to api-compiler-with-deps-0.0.5-SNAPSHOT.jar>'
 OPENAPI_FILE=<OpenAPI Spec filename>
 JSON_FILE_NAME=<json output file name>
 BINARY_FILE_NAME=<binary output file name>
 
-api-compiler \
+./run.sh \
 --openapi $OPENAPI_FILE \
 --json_out $JSON_FILE_NAME \
 --bin_out $BINARY_FILE_NAME
@@ -143,4 +115,29 @@ This will create the service configuration in different formats:
 - JSON file: $JSON_FILE_NAME
 
 Either format can be used to configure a Google Cloud Endpoints API.
+
+
+## Compile Google API Compiler
+
+Clone the _Google API Compiler_ repo
+```
+$ git clone https://github.com/googleapis/api-compiler
+```
+Update submodules
+```
+$ git submodule update --recursive --init
+```
+Build source code
+```
+$ ./gradlew buildApplication
+```
+For running tests, you need to have `protoc` in your path. If you don't
+already have protoc version 3, you can download
+it from https://github.com/google/protobuf/releases and set a symbolic link to
+the protoc.
+```
+# Example
+$ sudo ln -s  <Path to the downloaded protoc> /usr/local/bin/protoc
+```
+
 

--- a/build.gradle
+++ b/build.gradle
@@ -185,8 +185,8 @@ artifacts {
 
 // Jar with dependencies
 // ---------------------
-task buildGoogleApiConfigGen(type: Jar) {
-  baseName = googleApiConfigGenName + '-with-deps'
+task buildApplication(type: Jar) {
+  baseName = archivesBaseName + '-with-deps'
   from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
   with jar
   manifest {

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ apply plugin: "signing"
 apply plugin: "idea"
 apply plugin: "eclipse"
 apply plugin: "com.google.protobuf"
+apply plugin: "application"
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
@@ -26,7 +27,7 @@ version = "0.0.5-SNAPSHOT"
 // url to the snapshot repository of a private maven repo.
 def privateSnapshotRepo = "https://oss.sonatype.org/content/repositories/snapshots/"
 archivesBaseName = "api-compiler"
-
+mainClassName = "com.google.api.tools.framework.tools.configgen.ServiceConfigGeneratorTool"
 
 // TODO: fix error on Travis-CI and workstations without signing config:
 //       "Cannot perform signing task ':signArchives' because it has no configured signatory"
@@ -98,6 +99,12 @@ dependencies {
     libraries.mockito,
     libraries.truth,
     libraries.jodaTime
+}
+
+run {
+  if ( project.hasProperty("appArgs") ) {
+    args Eval.me(appArgs)
+  }
 }
 
 // Test data

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-name=gapi-tools-framework
-googleApiConfigGenName=gapi-config-gen
+name=api-compiler

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Combine all the arguments.
+printf -v var "'%s', " "$@"
+var=${var%??}
+
+# Invoke the application.
+./gradlew run -PappArgs="[$var]"
+


### PR DESCRIPTION
Thanks Martin for pointing to the application plugin. This simplifies the execution step of api-compiler.

- Rename the name of generated jar to be api-compiler.*
- Use Application plugin to make it easy to build jar as application. Therefore users will not be required to build first as a fat jar and run using java -jar. They can just do ./gradlew run