### PR TITLE
Fix NPE when compiling an openapi spec to a service config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ ext {
       apacheCommonCli: 'commons-cli:commons-cli:1.3',
       jsonSchemaValidator: 'com.github.fge:json-schema-validator:2.0.0',
 
+      slf4jSimple: 'org.slf4j:slf4j-simple:1.7.25',
+
       // Testing
       junit: 'junit:junit:4.11',
       mockito: 'org.mockito:mockito-core:1.10.19',
@@ -84,7 +86,8 @@ dependencies {
     libraries.snakeyaml,
     libraries.jsonSchemaValidator,
     libraries.grpcCore,
-    libraries.apacheCommonCli
+    libraries.apacheCommonCli,
+    libraries.slf4jSimple
 
   testCompile libraries.junit,
     libraries.mockito,
@@ -267,7 +270,7 @@ if (JavaVersion.current().isJava8Compatible()) {
         }
     }
 }
-    
+
 if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')) {
   uploadArchives {
     repositories {
@@ -321,4 +324,3 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
     + "and ossrhPassword properties need to be set correctly in "
     + "your ~/.gradle/gradle.properties file in order to upload archives.")
 }
-

--- a/src/main/java/com/google/api/tools/framework/tools/SwaggerToolDriverBase.java
+++ b/src/main/java/com/google/api/tools/framework/tools/SwaggerToolDriverBase.java
@@ -97,7 +97,7 @@ public abstract class SwaggerToolDriverBase extends GenericToolDriverBase {
 
   private Model setupModel() {
     // Prevent INFO messages from polluting the log.
-    Logger.getLogger("").setLevel(Level.WARNING);
+    // Logger.getLogger("").setLevel(Level.WARNING);
 
     try {
       serviceConfig = generateServiceConfig();

--- a/src/main/java/com/google/api/tools/framework/tools/ToolDriverBase.java
+++ b/src/main/java/com/google/api/tools/framework/tools/ToolDriverBase.java
@@ -76,7 +76,7 @@ public abstract class ToolDriverBase extends GenericToolDriverBase implements Mo
   /** Initializes the model. */
   private Model setupModel() {
     // Prevent INFO messages from polluting the log.
-    Logger.getLogger("").setLevel(Level.WARNING);
+    // Logger.getLogger("").setLevel(Level.WARNING);
 
     ModelBuildResult buildResult = new ModelBuilder().setup(options, this, getDataPath());
     this.diags = buildResult.getDiagCollector();

--- a/src/main/java/com/google/api/tools/framework/tools/ToolOptions.java
+++ b/src/main/java/com/google/api/tools/framework/tools/ToolOptions.java
@@ -197,7 +197,7 @@ public class ToolOptions {
           "descriptor_contents",
           "The descriptor set representing the compiled protos the tool works on. and its file"
               + " contents",
-          null);
+          FileWrapper.create("nothin", ""));
 
   public static final Option<List<String>> CONFIG_FILES =
       createOption(

--- a/src/main/java/com/google/api/tools/framework/tools/configgen/ConfigGeneratorFromSwagger.java
+++ b/src/main/java/com/google/api/tools/framework/tools/configgen/ConfigGeneratorFromSwagger.java
@@ -31,16 +31,16 @@ public class ConfigGeneratorFromSwagger extends SwaggerToolDriverBase implements
     super(options);
   }
 
-  @Override
-  @Nullable
-  public Service generateServiceConfig() throws IOException {
-    int exitCode = super.run();
-    if (exitCode == 1) {
-      return null;
-    } else {
-      return super.getServiceConfig();
-    }
-  }
+  // @Override
+  // @Nullable
+  // public Service generateServiceConfig() throws IOException {
+  //   int exitCode = super.run();
+  //   if (exitCode == 1) {
+  //     return null;
+  //   } else {
+  //     return super.getServiceConfig();
+  //   }
+  // }
 
   @Override
   public void process() throws Exception {


### PR DESCRIPTION
Hey @guptasu, here's a change that allows compiling an openapi spec to a service config (see #23).
I'm not sure if this change could interfere with other call paths.